### PR TITLE
Method for Searching by Exact Name Match

### DIFF
--- a/lib/countries/country/country_subdivision_methods.rb
+++ b/lib/countries/country/country_subdivision_methods.rb
@@ -10,12 +10,10 @@ module ISO3166
       end.values.first
     end
 
-    # @param subdivision_str [String] A subdivision name or code to search for.
+    # @param subdivision_str [String] A subdivision name to search for.
     # @return [Subdivision] The first subdivision exactly matching the provided string
     def find_subdivision_by_exact_name(subdivision_str)
-      subdivisions.find do |k, v|
-        subdivision_str == k || v.name == subdivision_str
-      end&.last
+      subdivisions.values.find { |v| v.name == subdivision_str }
     end
 
     def find_subdivision_by_unofficial_names(subdivision_str)

--- a/lib/countries/country/country_subdivision_methods.rb
+++ b/lib/countries/country/country_subdivision_methods.rb
@@ -10,10 +10,12 @@ module ISO3166
       end.values.first
     end
 
-    # @param subdivision_str [String] A subdivision name.
+    # @param subdivision_str [String] A subdivision name or code to search for.
     # @return [Subdivision] The first subdivision exactly matching the provided string
     def find_subdivision_by_exact_name(subdivision_str)
-      subdivisions.values.find { |v| v.name == subdivision_str }
+      subdivisions.find do |k, v|
+        subdivision_str == k || v.name == subdivision_str
+      end&.last
     end
 
     def find_subdivision_by_unofficial_names(subdivision_str)

--- a/lib/countries/country/country_subdivision_methods.rb
+++ b/lib/countries/country/country_subdivision_methods.rb
@@ -10,6 +10,12 @@ module ISO3166
       end.values.first
     end
 
+    # @param subdivision_str [String] A subdivision name.
+    # @return [Subdivision] The first subdivision exactly matching the provided string
+    def find_subdivision_by_exact_name(subdivision_str)
+      subdivisions.values.find { |v| v.name == subdivision_str }
+    end
+
     def find_subdivision_by_unofficial_names(subdivision_str)
       subdivisions.each do |k,v|
         return v if v.unofficial_names&.include?(subdivision_str)

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -1303,10 +1303,6 @@ describe ISO3166::Country do
     it 'should find a subdivision using the official name' do
       expect(ISO3166::Country.new('US').find_subdivision_by_exact_name('Washington')).to eq washington
     end
-
-    it 'should find a subdivision using the code' do
-      expect(ISO3166::Country.new('US').find_subdivision_by_exact_name('WA')).to eq washington
-    end
   end
 
   describe 'find_subdivision_by_unofficial_names', :focus do

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -1291,6 +1291,24 @@ describe ISO3166::Country do
     end
   end
 
+  describe 'find_subdivision_by_exact_name' do
+    let(:us_states) { ISO3166::Country.new('US') }
+    let(:washington) { us_states.subdivisions['WA'] }
+
+    before do
+      ISO3166.configuration.locales = %i[pt]
+      ISO3166::Data.reset
+    end
+
+    it 'should find a subdivision using the official name' do
+      expect(ISO3166::Country.new('US').find_subdivision_by_exact_name('Washington')).to eq washington
+    end
+
+    it 'should find a subdivision using the code' do
+      expect(ISO3166::Country.new('US').find_subdivision_by_exact_name('WA')).to eq washington
+    end
+  end
+
   describe 'find_subdivision_by_unofficial_names', :focus do
     let(:spain) { ISO3166::Country.new('ES') }
     let(:asturias) { spain.subdivisions['O'] }


### PR DESCRIPTION
`find_subdivision_by_name`, when searching with a name that matches a subdivision name exactly, would return whichever subdivision appeared first alphabetically, whether or not the subdivision was an exact match by name, or by a match in a translation name. This method will return the first subdivision, sorted alphabetically, that exactly matches the subdivision name without searching translations