### PR TITLE
make the find by subdivision method smarter

### DIFF
--- a/lib/countries/country/country_subdivision_methods.rb
+++ b/lib/countries/country/country_subdivision_methods.rb
@@ -3,11 +3,24 @@
 module ISO3166
   module CountrySubdivisionMethods
     # @param subdivision_str [String] A subdivision name or code to search for. Search includes translated subdivision names.
-    # @return [Subdivision] The first subdivision matching the provided string
+    # @return [Subdivision, nil] The first subdivision matching the provided string. If a match is found by code, it takes precedence over name, which takes precedence over translated names. Returns nil if no match is found.
     def find_subdivision_by_name(subdivision_str)
-      subdivisions.select do |k, v|
-        subdivision_str == k || v.name == subdivision_str || v.translations.values.include?(subdivision_str)
-      end.values.first
+      key_match = nil
+      name_match = nil
+      translation_match = nil
+
+      subdivisions.each do |k, v|
+        if subdivision_str == k
+          key_match = v
+          break # If we found a key match, no need to look further
+        elsif v.name == subdivision_str
+          name_match ||= v # Only set if it's not already set
+        elsif v.translations.values.include?(subdivision_str)
+          translation_match ||= v # Only set if it's not already set
+        end
+      end
+
+      key_match || name_match || translation_match
     end
 
     def subdivision_for_string?(subdivision_str)

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -1289,6 +1289,14 @@ describe ISO3166::Country do
     it 'should find a subdivision using a translated name' do
       expect(ISO3166::Country.new('IT').find_subdivision_by_name('Nápoles')).to eq napoli
     end
+
+    context "when multiple subdivisions may match" do
+      let(:washington_state) { ISO3166::Country.new('US').subdivisions['WA'] }
+
+      it 'should choose the subdivision that matches name over translated name' do
+        expect(ISO3166::Country.new('US').find_subdivision_by_name('Washington')).to eq washington_state
+      end
+    end
   end
 
   describe 'collect_countries_with' do


### PR DESCRIPTION
Patches the `find_subdivision_by_name` method to make it smarter.

- if input value matches a key/two letter code - it immediately stops iterating over the data and uses the matching reults
- if both a `name` and a `translated name` matches - it chooses the `name` which should be more accurate - e.g. the case of `Washington` state using a `translated name` match only if no `code` or `name` match is found